### PR TITLE
Python 3.6+ support only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 ## Changelog
 
+### v1.0.0
+
+- refactor fontname.py script to support Python 3.6+ interpreter only
+- drop support for all versions of the Python 2 interpreter
+- black source formatting
+- add support for [name table record ID 16](https://docs.microsoft.com/en-us/typography/opentype/spec/name) edits
+
 ### v0.3.0
 
-- bugfix: corrected PostScript nameID6 record suffix write. Previously spaces were not removed from this string value and they should be removed.
+- bugfix: corrected PostScript name table record ID 6 suffix write. Previously spaces were not removed from this string value and they should be removed.
 - minor update to control flow statement to make it more concise
 - source code formatting improvements
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 ## About
 
-`fontname.py` is a `.ttf` and `.otf` font renaming script that is developed in Python.  It supports font renaming with current versions of the Python 2 and Python 3 interpreters.
+`fontname.py` is a `.ttf` and `.otf` font renaming script that is developed in Python.  It supports font renaming with the Python 3.6+ interpreter.
 
 ## Dependency
-- [fonttools](https://github.com/fonttools/fonttools) Python library
+- [fonttools](https://github.com/fonttools/fonttools) Python library (requires v4.0.0+)
 
 Install with:
 
 ```
-pip install fonttools
+pip3 install fonttools
 ```
 
 ## Usage
@@ -18,31 +18,31 @@ pip install fonttools
 The script usage is as follows:
 
 ```
-$ python fontname.py [NEW FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>
+$ python3 fontname.py [NEW FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>
 ```
 
-This script updates the OpenType name table records nameID 1, 4, and 6 with appropriately formatted font names using the font variant already defined in the font file and the new font family name defined by the user as the first command line argument.  You can include any number of subsequent font file paths on the command line.  The variant type will be detected in the OpenType tables of the font(s) on the filepaths that are passed as arguments on the command line and will be used to create new name strings in the OpenType tables.
+This script updates the OpenType name table records nameID 1, 4, 6, and 16 with appropriately formatted font names using the font style definition in the font and the new font family name defined by the user as the first command line argument.  You can include any number of subsequent font paths on the command line.  The style will be detected in the OpenType tables of the fonts filepath arguments and will be used to create new name strings in the OpenType tables.
 
 **Note**: this re-writes the name tables in the fonts passed as arguments on the command line (i.e. writes files in place) so make copies first if you intend to maintain the fonts with the former naming for any reason (though you can simply re-write with the previous name if you forget...).
 
 ### Examples
 
 ```
-$ python fontname.py "Hack DEV" Hack-Regular.ttf
+$ python3 fontname.py "Hack DEV" Hack-Regular.ttf
 ```
 
 ![fscw-hack](https://user-images.githubusercontent.com/4249591/32151555-2a456982-bcf4-11e7-8ec8-57f8dbbd40a4.png)
 
 
 ```
-$ python fontname.py "Source Code Pro DEV" SourceCodePro-Regular.otf
+$ python3 fontname.py "Source Code Pro DEV" SourceCodePro-Regular.otf
 ```
 
 ![fscw-scp](https://user-images.githubusercontent.com/4249591/32151559-2e58a688-bcf4-11e7-9d39-7c8accdc41a6.png)
 
 
 ```
-$ python fontname.py "DejaVu Sans Mono DEV" DejaVuSansMono-Bold.ttf
+$ python3 fontname.py "DejaVu Sans Mono DEV" DejaVuSansMono-Bold.ttf
 ```
 
 ![fscw-djv](https://user-images.githubusercontent.com/4249591/32151564-3414a644-bcf4-11e7-93c3-93bc2bbaebdb.png)

--- a/fontname.py
+++ b/fontname.py
@@ -79,11 +79,13 @@ def main(argv):
             postscript_font_name = font_name.replace(" ", "")
             # font family name
             nameID1_string = font_name
+            nameID16_string = font_name
             # full font name
-            nameID4_string = font_name + " " + style
+            nameID4_string = f"{font_name} {style}"
             # Postscript name
             # - no spaces allowed in family name or the PostScript suffix. should be dash delimited
-            nameID6_string = postscript_font_name + "-" + style.replace(" ", "")
+            nameID6_string = f"{postscript_font_name}-{style.replace(' ', '')}"
+            # nameID6_string = postscript_font_name + "-" + style.replace(" ", "")
 
             # modify the opentype table data in memory with updated values
             for record in namerecord_list:
@@ -93,6 +95,8 @@ def main(argv):
                     record.string = nameID4_string
                 elif record.nameID == 6:
                     record.string = nameID6_string
+                elif record.nameID == 16:
+                    record.string = nameID16_string
 
         # write changes to the font file
         try:
@@ -100,7 +104,7 @@ def main(argv):
             print(f"[OK] Updated '{font_path}' with the name '{nameID4_string}'")
         except Exception as e:
             sys.stderr.write(
-                f"[fontname.py] ERROR: unable to write new name to OpenType tables for '{font_path}'. {os.linesep}"
+                f"[fontname.py] ERROR: unable to write new name to OpenType name table for '{font_path}'. {os.linesep}"
             )
             sys.stderr.write(f"{e}{os.linesep}")
             sys.exit(1)

--- a/fontname.py
+++ b/fontname.py
@@ -1,92 +1,67 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 # ==========================================================================
 # fontname.py
-# Copyright 2018 Christopher Simpkins
+# Copyright 2019 Christopher Simpkins
 # MIT License
 #
 # Dependencies:
-#   1) fonttools Python library (https://github.com/fonttools/fonttools)
-#         - install with `pip install fonttools`
+#   1) Python 3.6+ interpreter
+#   2) fonttools Python library (https://github.com/fonttools/fonttools)
+#         - install with `pip3 install fonttools`
 #
 # Usage:
-#   python fontname.py [FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>
+#   python3 fontname.py [FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>
 #
 # Notes:
 #   Use quotes around font family name arguments that included spaces
 # ===========================================================================
 
-from __future__ import unicode_literals
-
 import sys
 import os
 
 from fontTools import ttLib
-from fontTools.misc.py23 import tounicode, unicode
 
 
 def main(argv):
     # command argument tests
     print(" ")
     if len(argv) < 2:
-        sys.stderr.write(
-            "[fontname.py] ERROR: you did not include enough arguments to the script."
-            + os.linesep
-        )
-        sys.stderr.write(
-            "Usage: python fontname.py [FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>"
-            + os.linesep
-        )
+        sys.stderr.write(f"[fontname.py] ERROR: you did not include enough arguments to the script.{os.linesep}")
+        sys.stderr.write(f"Usage: python3 fontname.py [FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>{os.linesep}")
         sys.exit(1)
 
     # begin parsing command line arguments
     try:
-        font_name = tounicode(argv[0])  # the first argument is the new typeface name
-    except UnicodeDecodeError as e:
-        sys.stderr.write(
-            "[fontname.py] ERROR: Unable to convert argument to Unicode. "
-            + unicode(e)
-            + os.linesep
-        )
+        font_name = str(argv[0])  # the first argument is the new typeface name
+    except Exception as e:
+        sys.stderr.write(f"[fontname.py] ERROR: Unable to convert argument to string. {e}{os.linesep}")
         sys.exit(1)
 
-    font_path_list = argv[
-        1:
-    ]  # all remaining arguments on command line are file paths to fonts
+    # all remaining arguments on command line are file paths to fonts
+    font_path_list = argv[1:]
 
     # iterate through all paths provided on command line and rename to `font_name` defined by user
     for font_path in font_path_list:
         # test for existence of font file on requested file path
         if not file_exists(font_path):
-            sys.stderr.write(
-                "[fontname.py] ERROR: the path '"
-                + font_path
-                + "' does not appear to be a valid file path."
-                + os.linesep
-            )
+            sys.stderr.write(f"[fontname.py] ERROR: the path '{font_path}' does not appear to be a valid file path.{os.linesep}")
             sys.exit(1)
 
         tt = ttLib.TTFont(font_path)
         namerecord_list = tt["name"].names
-        variant = ""
 
-        # determine font variant for this file path from name record nameID 2
+        style = ""
+
+        # determine font style for this file path from name record nameID 2
         for record in namerecord_list:
             if record.nameID == 2:
-                variant = (
-                    record.toUnicode()
-                )  # cast to str type in Py 3, unicode type in Py 2
+                style = str(record)
                 break
 
-        # test that a variant name was found in the OpenType tables of the font
-        if len(variant) == 0:
-            sys.stderr.write(
-                "[fontname.py] Unable to detect the font variant from the OpenType name table in '"
-                + font_path
-                + "'."
-                + os.linesep
-            )
+        # test that a style name was found in the OpenType tables of the font
+        if len(style) == 0:
+            sys.stderr.write(f"[fontname.py] Unable to detect the font style from the OpenType name table in '{font_path}'. {os.linesep}")
             sys.stderr.write("Unable to complete execution of the script.")
             sys.exit(1)
         else:
@@ -95,10 +70,10 @@ def main(argv):
             # font family name
             nameID1_string = font_name
             # full font name
-            nameID4_string = font_name + " " + variant
+            nameID4_string = font_name + " " + style
             # Postscript name
             # - no spaces allowed in family name or the PostScript suffix. should be dash delimited
-            nameID6_string = postscript_font_name + "-" + variant.replace(" ", "")
+            nameID6_string = postscript_font_name + "-" + style.replace(" ", "")
 
             # modify the opentype table data in memory with updated values
             for record in namerecord_list:
@@ -112,21 +87,10 @@ def main(argv):
         # write changes to the font file
         try:
             tt.save(font_path)
-            print(
-                "[OK] Updated '"
-                + font_path
-                + "' with the name '"
-                + nameID4_string
-                + "'"
-            )
+            print(f"[OK] Updated '{font_path}' with the name '{nameID4_string}'")
         except Exception as e:
-            sys.stderr.write(
-                "[fontname.py] ERROR: unable to write new name to OpenType tables for '"
-                + font_path
-                + "'."
-                + os.linesep
-            )
-            sys.stderr.write(unicode(e))
+            sys.stderr.write(f"[fontname.py] ERROR: unable to write new name to OpenType tables for '{font_path}'. {os.linesep}")
+            sys.stderr.write(f"{e}{os.linesep}")
             sys.exit(1)
 
 
@@ -135,10 +99,7 @@ def main(argv):
 
 def file_exists(filepath):
     """Tests for existence of a file on the string filepath"""
-    if os.path.exists(filepath) and os.path.isfile(filepath):
-        return True
-    else:
-        return False
+    return os.path.exists(filepath) and os.path.isfile(filepath)
 
 
 if __name__ == "__main__":

--- a/fontname.py
+++ b/fontname.py
@@ -27,15 +27,21 @@ def main(argv):
     # command argument tests
     print(" ")
     if len(argv) < 2:
-        sys.stderr.write(f"[fontname.py] ERROR: you did not include enough arguments to the script.{os.linesep}")
-        sys.stderr.write(f"Usage: python3 fontname.py [FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>{os.linesep}")
+        sys.stderr.write(
+            f"[fontname.py] ERROR: you did not include enough arguments to the script.{os.linesep}"
+        )
+        sys.stderr.write(
+            f"Usage: python3 fontname.py [FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>{os.linesep}"
+        )
         sys.exit(1)
 
     # begin parsing command line arguments
     try:
         font_name = str(argv[0])  # the first argument is the new typeface name
     except Exception as e:
-        sys.stderr.write(f"[fontname.py] ERROR: Unable to convert argument to string. {e}{os.linesep}")
+        sys.stderr.write(
+            f"[fontname.py] ERROR: Unable to convert argument to string. {e}{os.linesep}"
+        )
         sys.exit(1)
 
     # all remaining arguments on command line are file paths to fonts
@@ -45,7 +51,9 @@ def main(argv):
     for font_path in font_path_list:
         # test for existence of font file on requested file path
         if not file_exists(font_path):
-            sys.stderr.write(f"[fontname.py] ERROR: the path '{font_path}' does not appear to be a valid file path.{os.linesep}")
+            sys.stderr.write(
+                f"[fontname.py] ERROR: the path '{font_path}' does not appear to be a valid file path.{os.linesep}"
+            )
             sys.exit(1)
 
         tt = ttLib.TTFont(font_path)
@@ -61,7 +69,9 @@ def main(argv):
 
         # test that a style name was found in the OpenType tables of the font
         if len(style) == 0:
-            sys.stderr.write(f"[fontname.py] Unable to detect the font style from the OpenType name table in '{font_path}'. {os.linesep}")
+            sys.stderr.write(
+                f"[fontname.py] Unable to detect the font style from the OpenType name table in '{font_path}'. {os.linesep}"
+            )
             sys.stderr.write("Unable to complete execution of the script.")
             sys.exit(1)
         else:
@@ -89,7 +99,9 @@ def main(argv):
             tt.save(font_path)
             print(f"[OK] Updated '{font_path}' with the name '{nameID4_string}'")
         except Exception as e:
-            sys.stderr.write(f"[fontname.py] ERROR: unable to write new name to OpenType tables for '{font_path}'. {os.linesep}")
+            sys.stderr.write(
+                f"[fontname.py] ERROR: unable to write new name to OpenType tables for '{font_path}'. {os.linesep}"
+            )
             sys.stderr.write(f"{e}{os.linesep}")
             sys.exit(1)
 

--- a/fontname.py
+++ b/fontname.py
@@ -14,7 +14,7 @@
 #   python3 fontname.py [FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>
 #
 # Notes:
-#   Use quotes around font family name arguments that included spaces
+#   Use quotes around font family name arguments that include spaces
 # ===========================================================================
 
 import sys


### PR DESCRIPTION
This PR refactors the `fontname.py` script to Python 3.6+ support only and requires `fonttools` package v4.0.0+.  Python 2 support is being eliminated.